### PR TITLE
feat: 添加 AutoCAD 2020 支持 (AFR-ACAD2020)

### DIFF
--- a/CADFontAutoReplace.slnx
+++ b/CADFontAutoReplace.slnx
@@ -5,6 +5,7 @@
   </Folder>
   <Folder Name="/AutoCAD/">
     <Project Path="src/AutoCAD/AFR.AutoCAD/AFR.AutoCAD.shproj" />
+    <Project Path="src/AutoCAD/AFR-ACAD2020/AFR-ACAD2020.csproj" />
     <Project Path="src/AutoCAD/AFR-ACAD2026/AFR-ACAD2026.csproj" />
   </Folder>
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <!-- AutoCAD SDK — 各版本通过 VersionOverride 指定不同版本号 -->
+    <!-- 25.1.0 = AutoCAD 2026 (net8.0), 23.1.0 = AutoCAD 2020 (net472) -->
     <PackageVersion Include="AutoCAD.NET" Version="25.1.0" />
     <!-- UI 控件库 -->
     <PackageVersion Include="HandyControl" Version="3.5.1" />

--- a/src/AFR.Core/Abstractions/ICadHost.cs
+++ b/src/AFR.Core/Abstractions/ICadHost.cs
@@ -14,7 +14,7 @@ public interface ICadHost
     /// CAD 主窗口的原生窗口句柄 (HWND)。
     /// 用于将 WPF 弹出窗口定位到 CAD 所在屏幕的中心位置。
     /// </summary>
-    nint MainWindowHandle { get; }
+    IntPtr MainWindowHandle { get; }
 
     /// <summary>
     /// 以模态方式显示一个 WPF 窗口。

--- a/src/AFR.Core/Models/FontCheckResult.cs
+++ b/src/AFR.Core/Models/FontCheckResult.cs
@@ -4,18 +4,31 @@ namespace AFR.Models;
 /// 单个文字样式的字体可用性检查结果。
 /// 记录该样式引用了哪些字体文件，以及这些字体在当前环境中是否缺失。
 /// </summary>
-/// <param name="StyleName">文字样式名称（如 "Standard"、"注释"）。</param>
-/// <param name="FileName">主字体文件名（SHX 文件名或 TrueType 字体族名）。</param>
-/// <param name="BigFontFileName">大字体文件名（仅 SHX 样式使用，TrueType 样式此值为空）。</param>
-/// <param name="IsMainFontMissing">主字体是否缺失（true 表示在可用字体列表中未找到）。</param>
-/// <param name="IsBigFontMissing">大字体是否缺失（仅对 SHX 样式有意义）。</param>
-/// <param name="IsTrueType">是否为 TrueType 字体样式（false 表示 SHX 字体样式）。</param>
-/// <param name="TypeFace">TrueType 字体的字体族名（SHX 样式此值为空）。</param>
-public sealed record FontCheckResult(
-    string StyleName,
-    string FileName,
-    string BigFontFileName,
-    bool IsMainFontMissing,
-    bool IsBigFontMissing,
-    bool IsTrueType,
-    string TypeFace);
+public sealed class FontCheckResult
+{
+    public string StyleName { get; }
+    public string FileName { get; }
+    public string BigFontFileName { get; }
+    public bool IsMainFontMissing { get; }
+    public bool IsBigFontMissing { get; }
+    public bool IsTrueType { get; }
+    public string TypeFace { get; }
+
+    public FontCheckResult(
+        string styleName,
+        string fileName,
+        string bigFontFileName,
+        bool isMainFontMissing,
+        bool isBigFontMissing,
+        bool isTrueType,
+        string typeFace)
+    {
+        StyleName = styleName;
+        FileName = fileName;
+        BigFontFileName = bigFontFileName;
+        IsMainFontMissing = isMainFontMissing;
+        IsBigFontMissing = isBigFontMissing;
+        IsTrueType = isTrueType;
+        TypeFace = typeFace;
+    }
+}

--- a/src/AFR.Core/Models/InlineFontFixRecord.cs
+++ b/src/AFR.Core/Models/InlineFontFixRecord.cs
@@ -4,12 +4,22 @@ namespace AFR.Models;
 /// 单条 MText（多行文字）内联字体映射的修复记录。
 /// 当 MText 内容中通过 \F 或 \f 引用了缺失字体时，记录修复的详细信息。
 /// </summary>
-/// <param name="MissingFont">缺失的原始字体名称。</param>
-/// <param name="ReplacementFont">用于替换的目标字体名称。</param>
-/// <param name="FixMethod">修复方式的描述（如 "SHX映射"、"TrueType映射"）。</param>
-/// <param name="FontCategory">字体分类（如 "SHX"、"TrueType"），用于统计和日志输出。</param>
-public sealed record InlineFontFixRecord(
-    string MissingFont,
-    string ReplacementFont,
-    string FixMethod,
-    string FontCategory);
+public sealed class InlineFontFixRecord
+{
+    public string MissingFont { get; }
+    public string ReplacementFont { get; }
+    public string FixMethod { get; }
+    public string FontCategory { get; }
+
+    public InlineFontFixRecord(
+        string missingFont,
+        string replacementFont,
+        string fixMethod,
+        string fontCategory)
+    {
+        MissingFont = missingFont;
+        ReplacementFont = replacementFont;
+        FixMethod = fixMethod;
+        FontCategory = fontCategory;
+    }
+}

--- a/src/AFR.Core/Models/StyleFontReplacement.cs
+++ b/src/AFR.Core/Models/StyleFontReplacement.cs
@@ -4,12 +4,36 @@ namespace AFR.Models;
 /// 单个文字样式的字体替换规格，描述应该用什么字体来替换缺失的字体。
 /// 由用户配置或自动匹配生成，供 FontReplacer 执行实际替换时使用。
 /// </summary>
-/// <param name="StyleName">要替换的文字样式名称。</param>
-/// <param name="IsTrueType">是否为 TrueType 字体样式（决定替换策略和可选字体范围）。</param>
-/// <param name="MainFontReplacement">主字体的替换目标（空字符串表示不替换主字体）。</param>
-/// <param name="BigFontReplacement">大字体的替换目标（仅 SHX 样式有效，空字符串表示不替换）。</param>
-public sealed record StyleFontReplacement(
-    string StyleName,
-    bool IsTrueType,
-    string MainFontReplacement,
-    string BigFontReplacement);
+public sealed class StyleFontReplacement
+{
+    public string StyleName { get; }
+    public bool IsTrueType { get; }
+    public string MainFontReplacement { get; }
+    public string BigFontReplacement { get; }
+
+    public StyleFontReplacement(
+        string styleName,
+        bool isTrueType,
+        string mainFontReplacement,
+        string bigFontReplacement)
+    {
+        StyleName = styleName;
+        IsTrueType = isTrueType;
+        MainFontReplacement = mainFontReplacement;
+        BigFontReplacement = bigFontReplacement;
+    }
+
+    /// <summary>创建副本并替换指定属性（等效于 record 的 with 表达式）。</summary>
+    public StyleFontReplacement With(
+        string? styleName = null,
+        bool? isTrueType = null,
+        string? mainFontReplacement = null,
+        string? bigFontReplacement = null)
+    {
+        return new StyleFontReplacement(
+            styleName ?? StyleName,
+            isTrueType ?? IsTrueType,
+            mainFontReplacement ?? MainFontReplacement,
+            bigFontReplacement ?? BigFontReplacement);
+    }
+}

--- a/src/AFR.Core/Services/ShxFontAnalyzer.cs
+++ b/src/AFR.Core/Services/ShxFontAnalyzer.cs
@@ -39,7 +39,7 @@ public static class ShxFontAnalyzer
             if (bytesRead < 25) return false;
 
             string headerStr = Encoding.ASCII.GetString(header, 0, bytesRead);
-            return headerStr.Contains("bigfont", StringComparison.OrdinalIgnoreCase);
+            return headerStr.IndexOf("bigfont", StringComparison.OrdinalIgnoreCase) >= 0;
         }
         catch
         {

--- a/src/AFR.UI/FontLog/FontReplacementLogWindow.xaml.cs
+++ b/src/AFR.UI/FontLog/FontReplacementLogWindow.xaml.cs
@@ -71,13 +71,15 @@ public partial class FontReplacementLogWindow : Window
                     existing = new StyleFontReplacement(row.StyleName, false, string.Empty, string.Empty);
 
                 map[row.StyleName] = row.IsBigFont
-                    ? existing with { BigFontReplacement = font }
-                    : existing with { MainFontReplacement = font, IsTrueType = row.IsTrueType };
+                    ? existing.With(bigFontReplacement: font)
+                    : existing.With(mainFontReplacement: font, isTrueType: row.IsTrueType);
             }
 
             DiagnosticLogger.Info("UI", $"应用替换: 从 {ViewModel.Items.Count} 行构建 {map.Count} 条替换指令");
-            foreach (var (name, rep) in map)
+            foreach (var kvp in map)
             {
+                var name = kvp.Key;
+                var rep = kvp.Value;
                 DiagnosticLogger.Info("UI",
                     $"  样式='{name}' Main='{rep.MainFontReplacement}' Big='{rep.BigFontReplacement}' IsTT={rep.IsTrueType}");
             }

--- a/src/AFR.UI/MTextEditor/MTextSyntaxHighlighter.cs
+++ b/src/AFR.UI/MTextEditor/MTextSyntaxHighlighter.cs
@@ -86,7 +86,7 @@ internal static partial class MTextSyntaxHighlighter
         {
             if (match.Index > lastIndex)
             {
-                paragraph.Inlines.Add(new Run(line[lastIndex..match.Index]));
+                paragraph.Inlines.Add(new Run(line.Substring(lastIndex, match.Index - lastIndex)));
             }
 
             var run = new Run(match.Value);
@@ -118,7 +118,7 @@ internal static partial class MTextSyntaxHighlighter
 
         if (lastIndex < line.Length)
         {
-            paragraph.Inlines.Add(new Run(line[lastIndex..]));
+            paragraph.Inlines.Add(new Run(line.Substring(lastIndex)));
         }
     }
 }

--- a/src/AFR.UI/WindowPositionHelper.cs
+++ b/src/AFR.UI/WindowPositionHelper.cs
@@ -11,7 +11,7 @@ namespace AFR.UI;
 internal static class WindowPositionHelper
 {
     [DllImport("user32.dll")]
-    private static extern bool GetWindowRect(nint hWnd, out RECT lpRect);
+    private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct RECT { public int Left, Top, Right, Bottom; }
@@ -31,8 +31,8 @@ internal static class WindowPositionHelper
 
     private static void CenterOnParentWindow(Window window)
     {
-        nint handle = PlatformManager.Host.MainWindowHandle;
-        if (handle == 0) return;
+        IntPtr handle = PlatformManager.Host.MainWindowHandle;
+        if (handle == IntPtr.Zero) return;
         if (!GetWindowRect(handle, out var rect)) return;
 
         // GetWindowRect 返回屏幕像素，WPF Left/Top 使用逻辑单位（96 DPI 基准）

--- a/src/AutoCAD/AFR-ACAD2020/AFR-ACAD2020.csproj
+++ b/src/AutoCAD/AFR-ACAD2020/AFR-ACAD2020.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <RootNamespace>AFR</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <LangVersion>latest</LangVersion>
+    <!-- .NET Framework 不支持 ArtifactsPath，使用默认输出路径 -->
+    <ArtifactsPath>$(MSBuildProjectDirectory)/artifacts</ArtifactsPath>
+    <UseArtifactsIntermediateOutput>false</UseArtifactsIntermediateOutput>
+    <!-- 独立管理 NuGet 版本，不使用中央包管理 -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- 导入共享源码 -->
+  <Import Project="..\..\AFR.Core\AFR.Core.projitems" Label="Shared" />
+  <Import Project="..\..\AFR.UI\AFR.UI.projitems" Label="Shared" />
+  <Import Project="..\AFR.AutoCAD\AFR.AutoCAD.projitems" Label="Shared" />
+
+  <ItemGroup>
+    <PackageReference Include="AutoCAD.NET">
+      <Version>23.1.0</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="HandyControl" Version="3.5.1" />
+  </ItemGroup>
+
+  <!-- 将 HandyControl DLL 嵌入为程序集资源，实现单 DLL 分发 -->
+  <Target Name="EmbedHandyControl" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'">
+        <LogicalName>%(Filename)%(Extension)</LogicalName>
+      </EmbeddedResource>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/AutoCAD/AFR-ACAD2020/AutoCad2020Platform.cs
+++ b/src/AutoCAD/AFR-ACAD2020/AutoCad2020Platform.cs
@@ -1,0 +1,17 @@
+using AFR.Abstractions;
+
+namespace AFR;
+
+internal sealed class AutoCad2020Platform : ICadPlatform
+{
+    public string BrandName => "AutoCAD";
+    public string VersionName => "2020";
+    public string AppName => "AFR-ACAD2020";
+    public string DisplayName => "AutoCAD 2020";
+    public string RegistryBasePath => @"Software\Autodesk\AutoCAD\R23.1";
+    public string RegistryKeyPattern => @"^ACAD-[A-Za-z0-9]+:[A-Za-z0-9]+$";
+    public string AcDbDllName => "acdb23.dll";
+    public string LdFileExport => "?ldfile@@YAHPEB_WHPEAVAcDbDatabase@@PEAVAcFontDescription@@@Z";
+    public int PrologueSize => 21;
+    public bool SupportsLdFileHook => true;
+}

--- a/src/AutoCAD/AFR-ACAD2020/PluginEntry.cs
+++ b/src/AutoCAD/AFR-ACAD2020/PluginEntry.cs
@@ -1,0 +1,19 @@
+using Autodesk.AutoCAD.Runtime;
+using AFR.Abstractions;
+using AFR.FontMapping;
+using AFR.Hosting;
+
+[assembly: ExtensionApplication(typeof(AFR.PluginEntry))]
+[assembly: CommandClass(typeof(AFR.Commands.AfrCommands))]
+#if DEBUG
+[assembly: CommandClass(typeof(AFR.Commands.MTextEditorCommand))]
+#endif
+
+namespace AFR;
+
+public class PluginEntry : PluginEntryBase
+{
+    protected override ICadPlatform CreatePlatform() => new AutoCad2020Platform();
+    protected override IFontHook CreateFontHook() => new AutoCadFontHook();
+    protected override ICadHost CreateHost() => new AutoCadHost();
+}

--- a/src/AutoCAD/AFR-ACAD2020/Properties/launchSettings.json
+++ b/src/AutoCAD/AFR-ACAD2020/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "AFR-ACAD2020": {
+      "commandName": "Project"
+    },
+    "AutoCAD 2020": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Autodesk\\AutoCAD 2020\\acad.exe",
+      "workingDirectory": "C:\\Program Files\\Autodesk\\AutoCAD 2020"
+    }
+  }
+}

--- a/src/AutoCAD/AFR.AutoCAD/FontMapping/LdFileHook.cs
+++ b/src/AutoCAD/AFR.AutoCAD/FontMapping/LdFileHook.cs
@@ -80,7 +80,7 @@ internal static class LdFileHook
         try
         {
             IntPtr module = GetModuleHandle(AcDbDll);
-            if (module == IntPtr.Zero) { DiagnosticLogger.Log("FontMapping", "acdb25.dll 未加载"); return; }
+            if (module == IntPtr.Zero) { DiagnosticLogger.Log("FontMapping", $"{AcDbDll} 未加载"); return; }
 
             _targetAddr = GetProcAddress(module, LdFileExport);
             if (_targetAddr == IntPtr.Zero) { DiagnosticLogger.Log("FontMapping", "未找到 ldfile 导出"); return; }
@@ -132,7 +132,8 @@ internal static class LdFileHook
 
             // 先用 NOP 填充整个序言区域，再写入跳转指令（确保不留残余的旧指令）
             byte[] hookPatch = new byte[PrologueSize];
-            Array.Fill(hookPatch, (byte)0x90);
+            for (int i = 0; i < hookPatch.Length; i++)
+                hookPatch[i] = 0x90;
             WriteAbsoluteJumpBytes(hookPatch, 0, hookAddr);
             Marshal.Copy(hookPatch, 0, _targetAddr, PrologueSize);
 
@@ -252,7 +253,7 @@ internal static class LdFileHook
                 // 归一化 key: SHX 字体确保 .shx 后缀（AutoCAD 可能传入无后缀的名称如 'noexistshx'），
                 // TrueType 使用去 @ 后的字族名。两者均与 MTextFontParser 的归一化规则对齐。
                 string normalizedName = isShxFont ? EnsureShx(baseName) : baseName;
-                _redirectLog.TryAdd(normalizedName, (resolved, param2));
+                if (!_redirectLog.ContainsKey(normalizedName)) _redirectLog.TryAdd(normalizedName, (resolved, param2));
 
                 DiagnosticLogger.Log("Hook", $"重定向: '{fontName}' param2={param2} → '{resolved}'");
 
@@ -286,7 +287,7 @@ internal static class LdFileHook
     private static string? ResolveMissingShxFont(string fontName, int fontType)
     {
         // @xxx.shx → 优先尝试去掉 @ 的基础字体（支持 @@xxx 双前缀）
-        if (fontName.StartsWith('@'))
+        if (fontName.StartsWith("@"))
         {
             string baseName = fontName.TrimStart('@');
             string baseShx = EnsureShx(baseName);
@@ -329,7 +330,7 @@ internal static class LdFileHook
     private static string? ResolveMissingTrueTypeFont(string fontName)
     {
         // @xxx → 优先尝试去掉 @ 的基础字族名（竖排 TrueType）
-        if (fontName.StartsWith('@'))
+        if (fontName.StartsWith("@"))
         {
             string baseName = fontName.TrimStart('@');
             if (FontDetector.IsSystemFont(baseName))

--- a/src/AutoCAD/AFR.AutoCAD/FontMapping/MTextFontParser.cs
+++ b/src/AutoCAD/AFR.AutoCAD/FontMapping/MTextFontParser.cs
@@ -95,7 +95,7 @@ internal static class MTextFontParser
         int end = FindTerminator(text, i, '|');
 
         // 提取 \F 到 | 之间的内容
-        string segment = text[i..end];
+        string segment = text.Substring(i, end - i);
         i = end < len ? end + 1 : end;
 
         if (string.IsNullOrWhiteSpace(segment)) return;
@@ -112,8 +112,8 @@ internal static class MTextFontParser
         else
         {
             // 主字体 + 大字体
-            string mainFont = segment[..commaPos].Trim();
-            string bigFont = segment[(commaPos + 1)..].Trim();
+            string mainFont = segment.Substring(0, commaPos).Trim();
+            string bigFont = segment.Substring(commaPos + 1).Trim();
 
             if (mainFont.Length > 0)
                 AddShxFont(mainFont, InlineFontType.ShxMain, result);
@@ -144,17 +144,17 @@ internal static class MTextFontParser
             if (c == ';')
             {
                 // 分号 → 确定的结束符
-                string fontName = text[nameStart..i].Trim();
+                string fontName = text.Substring(nameStart, i - nameStart).Trim();
                 i++; // 跳过 ;
                 if (fontName.Length > 0)
-                    result.TryAdd(fontName, InlineFontType.TrueType);
+                    if (!result.ContainsKey(fontName)) result.Add(fontName, InlineFontType.TrueType);
                 return;
             }
 
             if (c == '|')
             {
                 // | → 可能是结束符，也可能是参数分隔符
-                string fontName = text[nameStart..i].Trim();
+                string fontName = text.Substring(nameStart, i - nameStart).Trim();
                 i++; // 跳过 |
 
                 if (IsParameterStart(text, i))
@@ -165,16 +165,16 @@ internal static class MTextFontParser
 
                 // 无论哪种情况，字族名已确定
                 if (fontName.Length > 0)
-                    result.TryAdd(fontName, InlineFontType.TrueType);
+                    if (!result.ContainsKey(fontName)) result.Add(fontName, InlineFontType.TrueType);
                 return;
             }
 
             if (c == '\\')
             {
                 // 遇到新的转义序列 → 缺少终止符，容错截断
-                string fontName = text[nameStart..i].Trim();
+                string fontName = text.Substring(nameStart, i - nameStart).Trim();
                 if (fontName.Length > 0)
-                    result.TryAdd(fontName, InlineFontType.TrueType);
+                    if (!result.ContainsKey(fontName)) result.Add(fontName, InlineFontType.TrueType);
                 return;
             }
 
@@ -182,9 +182,9 @@ internal static class MTextFontParser
         }
 
         // 到达字符串末尾，缺少终止符 → 容错
-        string remaining = text[nameStart..].Trim();
+        string remaining = text.Substring(nameStart).Trim();
         if (remaining.Length > 0)
-            result.TryAdd(remaining, InlineFontType.TrueType);
+            if (!result.ContainsKey(remaining)) result.Add(remaining, InlineFontType.TrueType);
     }
 
     #region 辅助方法
@@ -211,11 +211,11 @@ internal static class MTextFontParser
         if (pos >= text.Length) return false;
 
         char c = text[pos];
-        if (c is not ('b' or 'i' or 'c' or 'p')) return false;
+        if (c != 'b' && c != 'i' && c != 'c' && c != 'p') return false;
 
         // 参数字母后必须紧跟数字
         int next = pos + 1;
-        return next < text.Length && char.IsAsciiDigit(text[next]);
+        return next < text.Length && char.IsDigit(text[next]);
     }
 
     /// <summary>
@@ -249,7 +249,7 @@ internal static class MTextFontParser
             ? fontName
             : fontName + ".shx";
 
-        result.TryAdd(normalized, fontType);
+        if (!result.ContainsKey(normalized)) result.Add(normalized, fontType);
     }
 
     #endregion

--- a/src/AutoCAD/AFR.AutoCAD/FontMapping/MTextInlineFontReplacer.cs
+++ b/src/AutoCAD/AFR.AutoCAD/FontMapping/MTextInlineFontReplacer.cs
@@ -25,8 +25,10 @@ internal static class MTextInlineFontReplacer
         string mainFont, string bigFont)
     {
         var missingTrueType = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var (fontName, inlineType) in inlineFonts)
+        foreach (var kvp in inlineFonts)
         {
+            var fontName = kvp.Key;
+            var inlineType = kvp.Value;
             if (inlineType == InlineFontType.TrueType
                 && !FontDetector.IsTrueTypeFontAvailable(fontName, context)
                 && !ContainsGarbledChars(fontName))
@@ -35,7 +37,7 @@ internal static class MTextInlineFontReplacer
             }
         }
 
-        if (missingTrueType.Count == 0) return [];
+        if (missingTrueType.Count == 0) return new List<InlineFontFixRecord>();
 
         string shxMain = StripShx(mainFont);
         string shxBig = StripShx(bigFont);
@@ -46,7 +48,7 @@ internal static class MTextInlineFontReplacer
         if (string.IsNullOrEmpty(shxMain) && string.IsNullOrEmpty(shxBig))
         {
             DiagnosticLogger.Log("MText替换", "未配置 SHX 替换字体，跳过 TrueType→SHX 转换");
-            return [];
+            return new List<InlineFontFixRecord>();
         }
 
         int modifiedCount = 0;
@@ -151,7 +153,7 @@ internal static class MTextInlineFontReplacer
         while (i < len && text[i] != '|' && text[i] != ';' && text[i] != '\\')
             i++;
 
-        string fontName = text[nameStart..i].Trim();
+        string fontName = text.Substring(nameStart, i - nameStart).Trim();
 
         if (fontName.Length > 0 && missingFonts.Contains(fontName))
         {
@@ -182,7 +184,7 @@ internal static class MTextInlineFontReplacer
 
         // 不需要转换 → 原样输出
         sb.Append('\\').Append('f');
-        sb.Append(text.AsSpan(nameStart, i - nameStart));
+        sb.Append(text.Substring(nameStart, i - nameStart));
 
         if (i < len)
         {
@@ -201,7 +203,7 @@ internal static class MTextInlineFontReplacer
                         i++;
                     if (i < len && text[i] == ';')
                         i++;
-                    sb.Append(text.AsSpan(paramStart, i - paramStart));
+                    sb.Append(text.Substring(paramStart, i - paramStart));
                 }
                 else
                 {
@@ -222,14 +224,14 @@ internal static class MTextInlineFontReplacer
     {
         if (pos >= text.Length) return false;
         char c = text[pos];
-        if (c is not ('b' or 'i' or 'c' or 'p')) return false;
+        if (c != 'b' && c != 'i' && c != 'c' && c != 'p') return false;
         int next = pos + 1;
-        return next < text.Length && char.IsAsciiDigit(text[next]);
+        return next < text.Length && char.IsDigit(text[next]);
     }
 
     private static string StripShx(string name) =>
         string.IsNullOrEmpty(name) ? "" :
-        name.EndsWith(".shx", StringComparison.OrdinalIgnoreCase) ? name[..^4] : name;
+        name.EndsWith(".shx", StringComparison.OrdinalIgnoreCase) ? name.Substring(0, name.Length - 4) : name;
 
     private static string EnsureShx(string name) =>
         name.EndsWith(".shx", StringComparison.OrdinalIgnoreCase) ? name : name + ".shx";

--- a/src/AutoCAD/AFR.AutoCAD/Hosting/AppInitializer.cs
+++ b/src/AutoCAD/AFR.AutoCAD/Hosting/AppInitializer.cs
@@ -39,7 +39,7 @@ internal static class AppInitializer
             var profiles = GetAcadProfiles();
             if (profiles.Count == 0)
             {
-                DiagnosticLogger.Log("初始化", "未找到有效的 AutoCAD R25.1 配置文件 (ACAD-xxxx:xxx)");
+                DiagnosticLogger.Log("初始化", $"未找到有效的 AutoCAD 配置文件 (ACAD-xxxx:xxx)，注册表路径: {PlatformManager.Platform.RegistryBasePath}");
                 return false;
             }
 

--- a/src/AutoCAD/AFR.AutoCAD/Hosting/AutoCadHost.cs
+++ b/src/AutoCAD/AFR.AutoCAD/Hosting/AutoCadHost.cs
@@ -9,7 +9,7 @@ namespace AFR.Hosting;
 internal sealed class AutoCadHost : ICadHost
 {
     /// <inheritdoc/>
-    public nint MainWindowHandle =>
+    public IntPtr MainWindowHandle =>
         Autodesk.AutoCAD.ApplicationServices.Core.Application.MainWindow.Handle;
 
     /// <summary>

--- a/src/AutoCAD/AFR.AutoCAD/Hosting/ExecutionController.cs
+++ b/src/AutoCAD/AFR.AutoCAD/Hosting/ExecutionController.cs
@@ -124,13 +124,13 @@ internal sealed class ExecutionController
                 #if DEBUG
                 if (inlineFonts.Count > 0)
                 {
-                    foreach (var (name, type) in inlineFonts)
-                        DiagnosticLogger.Log("MText内联", $"扫描到: '{name}' 类型={type}");
+                    foreach (var kvp in inlineFonts)
+                        DiagnosticLogger.Log("MText内联", $"扫描到: '{kvp.Key}' 类型={kvp.Value}");
                 }
                 if (redirectLog.Count > 0)
                 {
-                    foreach (var (key, (rep, ft)) in redirectLog)
-                        DiagnosticLogger.Log("MText内联", $"重定向记录: '{key}' → '{rep}' param2={ft}");
+                    foreach (var kvp in redirectLog)
+                        DiagnosticLogger.Log("MText内联", $"重定向记录: '{kvp.Key}' → '{kvp.Value.Replacement}' param2={kvp.Value.FontType}");
                 }
 #endif
 
@@ -185,8 +185,10 @@ internal sealed class ExecutionController
     {
         var records = new List<InlineFontFixRecord>();
 
-        foreach (var (fontName, inlineType) in inlineFonts)
+        foreach (var kvp in inlineFonts)
         {
+            var fontName = kvp.Key;
+            var inlineType = kvp.Value;
             if (!redirectLog.TryGetValue(fontName, out var redirect))
             {
                 // @ 前缀兼容: Hook 以 baseName（去 @）为 key 存储重定向记录，

--- a/src/AutoCAD/AFR.AutoCAD/Hosting/PluginEntryBase.cs
+++ b/src/AutoCAD/AFR.AutoCAD/Hosting/PluginEntryBase.cs
@@ -69,7 +69,13 @@ public abstract class PluginEntryBase : IExtensionApplication
         if (stream == null) return null;
 
         var data = new byte[stream.Length];
-        stream.ReadExactly(data);
+        int offset = 0;
+        while (offset < data.Length)
+        {
+            int read = stream.Read(data, offset, data.Length - offset);
+            if (read == 0) break;
+            offset += read;
+        }
         _resolvedHandyControl = Assembly.Load(data);
         return _resolvedHandyControl;
     }

--- a/src/AutoCAD/AFR.AutoCAD/Services/CadEnvironmentSettings.cs
+++ b/src/AutoCAD/AFR.AutoCAD/Services/CadEnvironmentSettings.cs
@@ -37,7 +37,7 @@ internal static class CadEnvironmentSettings
             var prefix = (string)AcadApp.GetSystemVariable("ACADPREFIX");
             if (!string.IsNullOrEmpty(prefix))
             {
-                foreach (var dir in prefix.Split(';', StringSplitOptions.RemoveEmptyEntries))
+                foreach (var dir in prefix.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                     TryAdd(dir.Trim(), paths, seen);
             }
         }
@@ -46,8 +46,7 @@ internal static class CadEnvironmentSettings
         // ── 2. AutoCAD 安装目录 Fonts ──
         try
         {
-            var processPath = Environment.ProcessPath
-                ?? Process.GetCurrentProcess().MainModule?.FileName;
+            var processPath = Process.GetCurrentProcess().MainModule?.FileName;
             if (processPath != null)
                 TryAdd(Path.Combine(Path.GetDirectoryName(processPath)!, "Fonts"), paths, seen);
         }

--- a/src/AutoCAD/AFR.AutoCAD/Services/DiagnosticLogger.cs
+++ b/src/AutoCAD/AFR.AutoCAD/Services/DiagnosticLogger.cs
@@ -426,8 +426,8 @@ internal static class DiagnosticLogger
         {
             if (_context.Count == 0) return "";
             var sb = new StringBuilder(" |");
-            foreach (var (key, value) in _context)
-                sb.Append($" {key}={value}");
+            foreach (var kvp in _context)
+                sb.Append($" {kvp.Key}={kvp.Value}");
             return sb.ToString();
         }
     }

--- a/src/AutoCAD/AFR.AutoCAD/Services/FontDetector.cs
+++ b/src/AutoCAD/AFR.AutoCAD/Services/FontDetector.cs
@@ -37,12 +37,12 @@ internal static class FontDetector
     {
         if (string.IsNullOrEmpty(name)) return false;
         var task = _systemFontNamesTask;
-        return task.IsCompletedSuccessfully && task.Result.Contains(name);
+        return task.IsCompleted && !task.IsFaulted && task.Result.Contains(name);
     }
 
     /// <summary>系统字体索引是否已构建完成且包含有效数据。</summary>
     public static bool IsSystemFontIndexReady
-        => _systemFontNamesTask.IsCompletedSuccessfully
+        => _systemFontNamesTask.IsCompleted && !_systemFontNamesTask.IsFaulted
            && _systemFontNamesTask.Result.Count > 0;
 
     /// <summary>
@@ -203,7 +203,7 @@ internal static class FontDetector
         // 第一处检查（跳过索引）和第二处检查（跳过 WPF 回退）同时成立，
         // 使已安装的 TrueType 字体被误判为缺失。
         var task = _systemFontNamesTask;
-        bool indexReady = task.IsCompletedSuccessfully;
+        bool indexReady = task.IsCompleted && !task.IsFaulted;
 
         if (indexReady && task.Result.Contains(typeface)) return true;
         if (!string.IsNullOrWhiteSpace(fileName))

--- a/src/AutoCAD/AFR.AutoCAD/Services/FontReplacer.cs
+++ b/src/AutoCAD/AFR.AutoCAD/Services/FontReplacer.cs
@@ -70,7 +70,7 @@ internal static class FontReplacer
         var missingMap = new Dictionary<string, FontCheckResult>(missingFonts.Count, StringComparer.OrdinalIgnoreCase);
         for (int i = 0; i < missingFonts.Count; i++)
         {
-            missingMap.TryAdd(missingFonts[i].StyleName, missingFonts[i]);
+            if (!missingMap.ContainsKey(missingFonts[i].StyleName)) missingMap.Add(missingFonts[i].StyleName, missingFonts[i]);
         }
 
         using var tr = context.Db.TransactionManager.StartTransaction();
@@ -191,7 +191,7 @@ internal static class FontReplacer
 
         var map = new Dictionary<string, StyleFontReplacement>(replacements.Count, StringComparer.OrdinalIgnoreCase);
         foreach (var r in replacements)
-            map.TryAdd(r.StyleName, r);
+            if (!map.ContainsKey(r.StyleName)) map.Add(r.StyleName, r);
 
         using var tr = context.Db.TransactionManager.StartTransaction();
         var styleTable = (TextStyleTable)tr.GetObject(context.Db.TextStyleTableId, OpenMode.ForRead);

--- a/src/AutoCAD/AFR.AutoCAD/Services/LogService.cs
+++ b/src/AutoCAD/AFR.AutoCAD/Services/LogService.cs
@@ -39,7 +39,7 @@ internal sealed class LogService : ILogService
     public static LogService Instance => _instance.Value;
 
     // 日志缓冲区：暂存所有日志条目（分类 + 消息 + 时间戳），Flush 时统一排序输出
-    private readonly List<(LogCategory Category, string Message, DateTime Timestamp)> _buffer = [];
+    private readonly List<(LogCategory Category, string Message, DateTime Timestamp)> _buffer = new List<(LogCategory, string, DateTime)>();
     // 记录已显示过 AFR 版本信息头的文档名，确保每个文档在整个会话中只显示一次横幅
     private readonly HashSet<string> _headerShownDocuments = new(StringComparer.OrdinalIgnoreCase);
     // 同步锁：保护 _buffer 和 _headerShownDocuments 的并发访问（AutoCAD 可能从不同线程触发日志写入）
@@ -236,8 +236,9 @@ internal sealed class LogService : ILogService
                         LogCategory.Info => $"\n[信息] {message}",
                         _ => $"\n{message}"
                     };
-                    // ??= 表示：如果该桶还没创建列表就先创建，然后再添加格式化后的消息
-                    (buckets[idx] ??= []).Add(formatted);
+                    // 如果该桶还没创建列表就先创建，然后再添加格式化后的消息
+                    if (buckets[idx] == null) buckets[idx] = new List<string>();
+                    buckets[idx].Add(formatted);
                 }
                 _buffer.Clear();
 


### PR DESCRIPTION
- 新增 AFR-ACAD2020 适配壳项目 (net472 + AutoCAD.NET 23.1.0)
- 共享代码适配 .NET Framework 4.7.2:
  - record 类型改为 class (避免 IsExternalInit 依赖)
  - nint 改为 IntPtr
  - Array.Fill / ReadExactly / TryAdd / IsCompletedSuccessfully 等替换为兼容写法
  - 范围运算符 / AsSpan / char重载StartsWith 等替换为 Substring/IndexOf
  - KeyValuePair 解构改为手动 Key/Value 访问
  - Environment.ProcessPath 改为 Process.GetCurrentProcess()
- AutoCad2020Platform: R23.1, acdb23.dll
- 两个版本均编译通过 (AFR-ACAD2026.dll + AFR-ACAD2020.dll)