### PR TITLE
加强 PR 保护：同时校验来源仓库与分支名

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,22 @@
+name: PR Branch Check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          echo "Base branch: ${{ github.base_ref }}"
+          echo "Head branch: ${{ github.head_ref }}"
+          
+          if [ "${{ github.head_ref }}" != "test" ]; then
+            echo "❌ Only test branch can merge into master!"
+            exit 1
+          else
+            echo "✅ Valid PR from test branch"
+          fi

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,10 +13,11 @@ jobs:
         run: |
           echo "Base branch: ${{ github.base_ref }}"
           echo "Head branch: ${{ github.head_ref }}"
+          echo "Head repository: ${{ github.event.pull_request.head.repo.full_name }}"
           
-          if [ "${{ github.head_ref }}" != "test" ]; then
-            echo "❌ Only test branch can merge into master!"
+          if [ "${{ github.head_ref }}" != "test" ] || [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "❌ Only the test branch from this repository can merge into master!"
             exit 1
           else
-            echo "✅ Valid PR from test branch"
+            echo "✅ Valid PR from this repository's test branch"
           fi


### PR DESCRIPTION
原工作流仅检查 PR head 分支名是否为 `test`，任何 fork 仓库创建同名分支均可绕过此保护。

## 变更

- 在分支名校验基础上，增加 `github.event.pull_request.head.repo.full_name == github.repository` 检查，确保 PR 必须来自**本仓库**的 `test` 分支才能合入 `master`

```yaml
if [ "${{ github.head_ref }}" != "test" ] || \
   [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
  echo "❌ Only the test branch from this repository can merge into master!"
  exit 1
fi
```