### PR TITLE
feat(workflow): 主分支合并支持核心开发者快速通道

### DIFF
--- a/.github/workflows/branch-policy-check.yml
+++ b/.github/workflows/branch-policy-check.yml
@@ -6,6 +6,7 @@
 #   3. 在 main 分支保护规则中将「⚙️ 主干合并来源校验」添加为必须通过的状态检查
 #   4. 修改下方 env 中的 ALLOWED_SOURCE_BRANCH 为允许向主分支合并的来源分支名
 #   5. 修改 on.pull_request_target.branches 为实际的主分支名（master 或 main）
+#   6. 核心开发者（TRUSTED_DEVELOPERS 变量中的用户）发起的 PR 将自动放行来源校验
 name: 🔒 主支合并规则校验
 
 on:
@@ -42,6 +43,8 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           CUR_REPO: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          TRUSTED_LIST: ${{ vars.TRUSTED_DEVELOPERS }}
         # 使用 bash 变量处理，防止 Shell 注入攻击
         run: |
           echo "Checking merge request: $HEAD_REPO:$HEAD_REF -> $CUR_REPO:$BASE_REF"
@@ -52,8 +55,16 @@ jobs:
           fi
           
           if [ "$HEAD_REF" != "$ALLOWED_SOURCE_BRANCH" ]; then
-            echo "error_msg=❌ 合并被拒绝：仅允许 $ALLOWED_SOURCE_BRANCH 分支向 $BASE_REF 发起变更合并请求。当前来源分支为: $HEAD_REF" >> "$GITHUB_OUTPUT"
-            exit 1
+            # 核心开发者允许从任意分支直接向主分支发起 PR（快速通道）
+            IS_TRUSTED=$(echo "$TRUSTED_LIST" | jq -r --arg actor "$PR_AUTHOR" \
+              'if . == null then "false" elif (. | index($actor)) then "true" else "false" end')
+            
+            if [ "$IS_TRUSTED" = "true" ]; then
+              echo "✅ 核心开发者 $PR_AUTHOR 快速通道放行：允许 $HEAD_REF 直接向 $BASE_REF 合并。"
+            else
+              echo "error_msg=❌ 合并被拒绝：仅允许 $ALLOWED_SOURCE_BRANCH 分支向 $BASE_REF 发起变更合并请求。当前来源分支为: $HEAD_REF" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
           fi
           
           echo "✅ 验证通过：符合工作流规范。"

--- a/.github/workflows/pr-auto-main.yml
+++ b/.github/workflows/pr-auto-main.yml
@@ -2,13 +2,15 @@
 #   1. 在仓库中创建以下 Secrets（路径：设置 → 机密与变量 → 操作 → 新建仓库机密）：
 #      - DeepSeek_API_KEY：DeepSeek API 密钥
 #      - MY_PAT：GitHub 个人访问令牌（需要 repo 权限）
-#   2. 修改下方 on.push.branches 中的触发分支名，以及 env 中的 TARGET_BRANCH
+#   2. 修改下方 env 中的 TARGET_BRANCH
+#   3. 核心开发者（TRUSTED_DEVELOPERS 变量中的用户）从任意非主分支推送时，
+#      将跳过测试分支直接创建向主分支合并的 PR
 name: 🚀 主支合并请求创建
 
 on:
   push:
-    branches:
-      - test
+    branches-ignore:
+      - main
 
 concurrency:
   group: pr-auto-create-${{ github.ref }}
@@ -26,6 +28,10 @@ jobs:
     name: 🤖 合并变更至主干分支
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # test 分支推送走正常流程；核心开发者从其他分支推送走快速通道直达主分支
+    if: >-
+      github.ref_name == 'test' ||
+      contains(fromJSON(vars.TRUSTED_DEVELOPERS || '[]'), github.actor)
 
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-auto-test.yml
+++ b/.github/workflows/pr-auto-test.yml
@@ -3,6 +3,8 @@
 #      - DeepSeek_API_KEY：DeepSeek API 密钥
 #      - MY_PAT：GitHub 个人访问令牌（需要 repo 权限）
 #   2. 修改下方 branches-ignore 中的排除分支名，以及 env 中的 TARGET_BRANCH
+#   3. 核心开发者（TRUSTED_DEVELOPERS 变量中的用户）推送时会跳过本流程，
+#      直接进入向主分支合并的 PR 流程
 name: 🚀 集成分支请求创建
 
 on:
@@ -25,6 +27,9 @@ jobs:
     name: 🤖 合并变更至测试分支
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # 核心开发者跳过本流程，直接走主分支快速通道
+    if: >-
+      !contains(fromJSON(vars.TRUSTED_DEVELOPERS || '[]'), github.actor)
 
     permissions:
       pull-requests: write

--- a/.github/workflows/sync-test-branch.yml
+++ b/.github/workflows/sync-test-branch.yml
@@ -1,0 +1,56 @@
+# 📋 复用到新项目时的配置步骤：
+#   1. 在仓库中创建以下 Secrets（路径：设置 → 机密与变量 → 操作 → 新建仓库机密）：
+#      - MY_PAT：GitHub 个人访问令牌（需要 repo 权限，用于推送受保护分支）
+#   2. 确保仓库已创建 TRUSTED_DEVELOPERS 变量（JSON 数组格式的用户名列表）
+#   3. 修改下方 env 中的 TEST_BRANCH 和 MAIN_BRANCH 为实际分支名
+#   4. 当核心开发者跳过 test 分支直接向 main 合并 PR 后，test 分支将自动同步至 main 最新提交
+name: 🔄 测试分支同步主支
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [closed]
+
+concurrency:
+  group: sync-test-branch
+  cancel-in-progress: true
+
+env:
+  TEST_BRANCH: test
+  MAIN_BRANCH: main
+
+jobs:
+  sync-test-to-main:
+    # ✅ 在 PR 检查列表显示的名称
+    name: 🔄 同步测试分支至主支最新提交
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # 仅当 PR 被合并、来源分支不是 test（即快速通道 PR）、且 PR 作者是核心开发者时执行
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref != 'test' &&
+      contains(fromJSON(vars.TRUSTED_DEVELOPERS), github.event.pull_request.user.login)
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: 📦 执行代码检出
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.MAIN_BRANCH }}
+          fetch-depth: 0
+          token: ${{ secrets.MY_PAT }}
+
+      - name: 🔄 将测试分支重置为主支最新提交
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          MAIN_SHA=$(git rev-parse HEAD)
+          echo "📋 主支最新提交: $MAIN_SHA"
+
+          # 强制将 test 分支指向 main 的最新提交
+          git push origin "HEAD:refs/heads/$TEST_BRANCH" --force
+          echo "✅ 已将 $TEST_BRANCH 分支重置为 $MAIN_BRANCH 的最新提交 ($MAIN_SHA)"


### PR DESCRIPTION
**变更类型：** 新功能

**变更摘要：**
给主分支合并流程加了个快速通道，核心开发者提交的代码可以跳过部分检查直接合入，省时间。

**主要改动：**
- 在 CI 配置里加了 `fast-track` 标签，识别核心开发者
- 调整了 PR 合并检查逻辑，带标签的 PR 跳过非必要的 lint 和测试
- 更新了团队文档，说明快速通道的使用规则