### PR TITLE
refactor(build): 集中管理 HandyControl 嵌入逻辑

### DIFF
--- a/src/AutoCAD/AFR-ACAD2024/AFR-ACAD2024.csproj
+++ b/src/AutoCAD/AFR-ACAD2024/AFR-ACAD2024.csproj
@@ -23,18 +23,6 @@
     <PackageReference Include="AutoCAD.NET" VersionOverride="24.3.0">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <!-- UI 控件库 — 嵌入为程序集资源，不复制到输出 -->
-    <PackageReference Include="HandyControl" />
   </ItemGroup>
-
-  <!-- 将 HandyControl DLL 嵌入为程序集资源，实现单 DLL 分发 -->
-  <Target Name="EmbedHandyControl" AfterTargets="ResolveAssemblyReferences">
-    <ItemGroup>
-      <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'">
-        <LogicalName>%(Filename)%(Extension)</LogicalName>
-      </EmbeddedResource>
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'" />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/AutoCAD/AFR-ACAD2026/AFR-ACAD2026.csproj
+++ b/src/AutoCAD/AFR-ACAD2026/AFR-ACAD2026.csproj
@@ -20,18 +20,6 @@
     <PackageReference Include="AutoCAD.NET">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <!-- UI 控件库 — 嵌入为程序集资源，不复制到输出 -->
-    <PackageReference Include="HandyControl" />
   </ItemGroup>
-
-  <!-- 将 HandyControl DLL 嵌入为程序集资源，实现单 DLL 分发 -->
-  <Target Name="EmbedHandyControl" AfterTargets="ResolveAssemblyReferences">
-    <ItemGroup>
-      <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'">
-        <LogicalName>%(Filename)%(Extension)</LogicalName>
-      </EmbeddedResource>
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'" />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/AutoCAD/Directory.Build.targets
+++ b/src/AutoCAD/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project>
+  <ItemGroup>
+    <!-- UI 控件库 — 嵌入为程序集资源，不复制到输出 -->
+    <PackageReference Include="HandyControl" />
+  </ItemGroup>
+
+  <!-- 将 HandyControl DLL 嵌入为程序集资源，实现单 DLL 分发 -->
+  <Target Name="EmbedHandyControl" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'">
+        <LogicalName>%(Filename)%(Extension)</LogicalName>
+      </EmbeddedResource>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
**变更类型：** refactor

**变更摘要：**
将 HandyControl 程序集嵌入逻辑从各项目文件提取至共享的 Directory.Build.targets 文件，以消除重复配置并提升构建脚本的可维护性。

**主要改动：**
- 其他：在 AutoCAD 目录下新增 Directory.Build.targets 文件，集中定义 HandyControl 的 NuGet 包引用及其嵌入为程序集资源的 MSBuild 目标。
- 其他：从 AFR-ACAD2024 与 AFR-ACAD2026 的项目文件中移除重复的 HandyControl 包引用和 EmbedHandyControl 目标定义，改为继承共享配置。