### PR TITLE
refactor(build): 重构 HandyControl 依赖管理并更新文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 [GitHub](https://github.com/splrad/CADFontAutoReplace) · [Gitee（国内镜像）](https://gitee.com/splrad/CADFontAutoReplace) · [Releases](https://github.com/splrad/CADFontAutoReplace/releases) · [提交 Issue](https://github.com/splrad/CADFontAutoReplace/issues)
 
+**📥 补充下载链接：[蓝奏云网盘](https://wwbcq.lanzouv.com/b01jt1w7of) （密码: exsc）**
+
 </div>
 
 ---

--- a/src/AutoCAD/AFR-ACAD2024/AFR-ACAD2024.csproj
+++ b/src/AutoCAD/AFR-ACAD2024/AFR-ACAD2024.csproj
@@ -23,18 +23,6 @@
     <PackageReference Include="AutoCAD.NET" VersionOverride="24.3.0">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <!-- UI 控件库 — 嵌入为程序集资源，不复制到输出 -->
-    <PackageReference Include="HandyControl" />
   </ItemGroup>
-
-  <!-- 将 HandyControl DLL 嵌入为程序集资源，实现单 DLL 分发 -->
-  <Target Name="EmbedHandyControl" AfterTargets="ResolveAssemblyReferences">
-    <ItemGroup>
-      <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'">
-        <LogicalName>%(Filename)%(Extension)</LogicalName>
-      </EmbeddedResource>
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'" />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/AutoCAD/AFR-ACAD2026/AFR-ACAD2026.csproj
+++ b/src/AutoCAD/AFR-ACAD2026/AFR-ACAD2026.csproj
@@ -20,18 +20,6 @@
     <PackageReference Include="AutoCAD.NET">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <!-- UI 控件库 — 嵌入为程序集资源，不复制到输出 -->
-    <PackageReference Include="HandyControl" />
   </ItemGroup>
-
-  <!-- 将 HandyControl DLL 嵌入为程序集资源，实现单 DLL 分发 -->
-  <Target Name="EmbedHandyControl" AfterTargets="ResolveAssemblyReferences">
-    <ItemGroup>
-      <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'">
-        <LogicalName>%(Filename)%(Extension)</LogicalName>
-      </EmbeddedResource>
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'" />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/AutoCAD/Directory.Build.targets
+++ b/src/AutoCAD/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project>
+  <ItemGroup>
+    <!-- UI 控件库 — 嵌入为程序集资源，不复制到输出 -->
+    <PackageReference Include="HandyControl" />
+  </ItemGroup>
+
+  <!-- 将 HandyControl DLL 嵌入为程序集资源，实现单 DLL 分发 -->
+  <Target Name="EmbedHandyControl" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'">
+        <LogicalName>%(Filename)%(Extension)</LogicalName>
+      </EmbeddedResource>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'HandyControl'" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
**变更类型：** 混合变更（refactor/docs）

**变更摘要：**
将 HandyControl 的 NuGet 包引用和嵌入构建逻辑从各项目文件提取至公共的 Directory.Build.targets 文件，以统一依赖管理并减少配置重复，同时为 README 补充下载链接以提升用户获取效率。

**主要改动：**
- 其他：在 AutoCAD 模块引入 Directory.Build.targets 文件，集中定义 HandyControl 的 PackageReference 和 EmbedHandyControl 构建目标，消除 AFR-ACAD2024 与 AFR-ACAD2026 项目中的重复配置项。
- 文档更新：在 README 文档中新增蓝奏云网盘下载链接与提取密码，完善分发渠道信息。