### PR TITLE
docs(test): 添加 Adobe Acrobat DC 字体问题解决文档

### DIFF
--- a/TEST 6.md
+++ b/TEST 6.md
@@ -1,0 +1,5 @@
+# Adobe Acrobat DC 中发票字体显示不全
+
+使用下列文件复制到Adobe Acrobat DC安装目录中的C:\Program Files\Adobe\Acrobat DC\Resource\Font（此为默认安装位置）文件夹中。
+
+> https://wwi.lanzoup.com/b08cfbcpe 密码:2uhl


### PR DESCRIPTION
**变更类型：** docs

**变更摘要：**
新增一份关于 Adobe Acrobat DC 中发票字体显示不全问题的解决方案文档，以提供明确的文件替换路径和资源指引。

**主要改动：**
- 文档更新：创建 `TEST 6.md` 文件，详细说明字体文件的下载链接、提取密码及在 Adobe Acrobat DC 安装目录中的具体放置路径。
- 其他：提供外部资源链接，用于获取缺失的字体文件以解决显示兼容性问题。