### PR TITLE
ci: 重构 CI/CD 工作流编排与发布流程

### DIFF
--- a/.github/workflows/branch-policy-check.yml
+++ b/.github/workflows/branch-policy-check.yml
@@ -3,15 +3,12 @@
 #      禁止任何人直接推送到主分支，所有变更必须通过 PR 合入
 #   2. 在 main 分支保护规则中将「⚙️ 合并来源校验」添加为必须通过的状态检查
 #   3. 修改下方 env 中的 ALLOWED_SOURCE_BRANCH 为允许向主分支合并的来源分支名
-#   4. 修改 on.pull_request_target.branches 为实际的主分支名（master 或 main）
+#   4. 如需限制触发分支，请在编排工作流中配置 pull_request_target.branches（建议在 orchestrate-pr-events.yml 中维护）
 #   5. 核心开发者（TRUSTED_DEVELOPERS 变量中的用户）发起的 PR 将自动放行来源校验
 name: 🔒 主干分支合并规则校验
 
 on:
-  pull_request_target:
-    branches:
-      - main
-    types: [opened, synchronize, reopened]
+  workflow_call:
 
 concurrency:
   group: pr-branch-check-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/merge-permission.yml
+++ b/.github/workflows/merge-permission.yml
@@ -8,10 +8,7 @@
 name: 🛡️ 合并审批权限校验
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-  pull_request_review:
-    types: [submitted, dismissed]
+  workflow_call:
 
 concurrency:
   group: merge-permission-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/orchestrate-pr-close.yml
+++ b/.github/workflows/orchestrate-pr-close.yml
@@ -1,0 +1,37 @@
+name: 📣 PR关闭链路编排
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [closed]
+
+concurrency:
+  group: orchestrate-pr-close-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: write
+
+jobs:
+  pr-close-notify:
+    name: 📣 PR关闭状态通知
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.state == 'closed'
+    uses: ./.github/workflows/pr-close-notify.yml
+    secrets: inherit
+
+  sync-test-branch:
+    name: 🔄 重置测试分支到主分支
+    needs: pr-close-notify
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.state == 'closed'
+    uses: ./.github/workflows/sync-test-branch.yml
+    secrets: inherit

--- a/.github/workflows/orchestrate-pr-events.yml
+++ b/.github/workflows/orchestrate-pr-events.yml
@@ -1,0 +1,42 @@
+name: 🛡️ PR变更链路编排
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+concurrency:
+  group: orchestrate-pr-events-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  auto-approve:
+    name: 🛡️ 合并审批自动授权
+    if: github.event_name == 'pull_request_target'
+    uses: ./.github/workflows/pr-auto-approve.yml
+    secrets: inherit
+
+  merge-permission:
+    name: ${{ github.event.pull_request.base.ref == 'main' && '🔐 主分支合并权限审计' || '🔒 自动化资源保护规则' }}
+    needs: auto-approve
+    if: >-
+      always() &&
+      (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review')
+    uses: ./.github/workflows/merge-permission.yml
+    secrets: inherit
+
+  branch-policy-check:
+    name: ⚙️ 合并来源校验
+    needs: merge-permission
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.base.ref == 'main'
+    uses: ./.github/workflows/branch-policy-check.yml
+    secrets: inherit

--- a/.github/workflows/orchestrate-push-events.yml
+++ b/.github/workflows/orchestrate-push-events.yml
@@ -1,0 +1,49 @@
+name: 🚀 分支推送链路编排
+
+on:
+  push:
+    branches:
+      - '**'
+
+concurrency:
+  group: orchestrate-push-events-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: write
+
+jobs:
+  pr-auto-test:
+    name: 🚀 测试分支合并请求创建
+    if: >-
+      github.ref_name != 'test' &&
+      github.ref_name != 'main' &&
+      !contains(fromJSON(vars.TRUSTED_DEVELOPERS || '[]'), github.actor)
+    uses: ./.github/workflows/pr-auto-test.yml
+    secrets: inherit
+
+  pr-auto-main:
+    name: 🚀 主干分支合并请求创建
+    needs: pr-auto-test
+    if: >-
+      always() &&
+      (
+        github.ref_name == 'test' ||
+        (
+          github.ref_name != 'main' &&
+          contains(fromJSON(vars.TRUSTED_DEVELOPERS || '[]'), github.actor)
+        )
+      )
+    uses: ./.github/workflows/pr-auto-main.yml
+    secrets: inherit
+
+  sync-test-branch:
+    name: 🔄 重置测试分支到主分支
+    needs: pr-auto-main
+    if: >-
+      always() &&
+      github.ref_name == 'main'
+    uses: ./.github/workflows/sync-test-branch.yml
+    secrets: inherit

--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 5
     # 只有当 PR 作者在核心开发者列表中时，执行自动审批（覆盖 feature→test 和 test→main 两层 PR）
     if: >-
-      contains(fromJSON(vars.TRUSTED_DEVELOPERS), github.actor)
+      contains(fromJSON(vars.TRUSTED_DEVELOPERS || '[]'), github.actor)
     permissions:
       pull-requests: write
 
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: >-
-      !contains(fromJSON(vars.TRUSTED_DEVELOPERS), github.actor)
+      !contains(fromJSON(vars.TRUSTED_DEVELOPERS || '[]'), github.actor)
     permissions:
       contents: read
 

--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -12,8 +12,7 @@
 name: 🛡️ 合并审批自动授权
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+  workflow_call:
 
 concurrency:
   group: auto-approve-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-auto-main.yml
+++ b/.github/workflows/pr-auto-main.yml
@@ -13,9 +13,7 @@
 name: 🚀 主干分支合并请求创建
 
 on:
-  push:
-    branches-ignore:
-      - main
+  workflow_call:
 
 concurrency:
   group: pr-auto-create-${{ github.ref }}

--- a/.github/workflows/pr-auto-test.yml
+++ b/.github/workflows/pr-auto-test.yml
@@ -3,7 +3,7 @@
 #      Secret 名称必须与下方完全一致（区分大小写）：
 #      - DeepSeek_API_KEY：DeepSeek Key，示例值格式：sk-xxxxxxxx
 #      - REPO_ADMIN_TOKEN：GitHub PAT（建议最小权限覆盖：Pull requests 读写、Issues 读写、Contents 只读）
-#   2) 修改下方 branches-ignore 与 TARGET_BRANCH，使其符合你的测试分支命名
+#   2) 修改编排工作流中的 push 过滤规则与下方 TARGET_BRANCH，使其符合你的测试分支命名
 #   3) 可选：在仓库 Variables 中创建 TRUSTED_DEVELOPERS（JSON 数组）
 #      示例：["splrad", "another-user"]
 #      命中该名单的用户将跳过本流程，直接进入主分支 PR 快速通道
@@ -13,10 +13,7 @@
 name: 🚀 测试分支合并请求创建
 
 on:
-  push:
-    branches-ignore:
-      - test
-      - main
+  workflow_call:
 
 concurrency:
   group: pr-to-test-${{ github.ref }}

--- a/.github/workflows/pr-close-notify.yml
+++ b/.github/workflows/pr-close-notify.yml
@@ -1,16 +1,14 @@
 # 📋 复用到新项目时的配置步骤：
 #   0. （可选）创建 REPO_ADMIN_TOKEN（或 MY_PAT）用于读取 API 的回退访问；评论写入不会回退到该令牌
 #   1. 确保仓库已创建 TRUSTED_DEVELOPERS 变量（JSON 数组格式的用户名列表）
-#   2. 修改下方 on.pull_request_target.branches 为实际主分支名（main 或 master）
+#   2. 在编排工作流中配置 pull_request_target.branches 为实际主分支名（main 或 master）
 #   3. 当 PR 关闭时自动发布状态评论，并通过评论中的 @对象触发 GitHub 官方通知邮件
-#   4. 若日志出现 github.token 无写权限，先确认仓库 Actions 默认权限为 Read and write，再确认本工作流 jobs.permissions 含 pull-requests: write 与 issues: write
+#   4. 未合并关闭 PR 时，最后一条非机器人评论必须来自关闭人；否则将自动恢复为打开状态
+#   5. 若日志出现 github.token 无写权限，先确认仓库 Actions 默认权限为 Read and write，再确认本工作流 jobs.permissions 含 pull-requests: write 与 issues: write
 name: 📣 PR关闭状态通知
 
 on:
-  pull_request_target:
-    branches:
-      - main
-    types: [closed]
+  workflow_call:
 
 concurrency:
   group: pr-close-notify-${{ github.event.pull_request.number || github.run_id }}
@@ -20,6 +18,10 @@ jobs:
   notify-pr-close-status:
     # ✅ 在 PR 检查列表显示的名称
     name: 📣 发布PR关闭状态通知
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.state == 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 3
 
@@ -130,6 +132,35 @@ jobs:
             "repos/$REPO/issues/$issue_number/comments" \
             -f per_page=100)
 
+          last_human_comment_author='无'
+          last_human_comment_body='无'
+          last_human_comment_url=''
+
+          last_human_comment_json=$(echo "$comments_json" | jq -c --arg marker "$marker" '
+            [ .[]
+              | select((.body // "") != "")
+              | select(((.user.type // "") | ascii_downcase) != "bot")
+              | select(((.user.login // "") | test("\\[bot\\]$")) | not)
+              | select(((.body // "") | contains($marker)) | not)
+            ]
+            | sort_by(.created_at)
+            | last // empty
+          ')
+
+          if [ -n "$last_human_comment_json" ]; then
+            last_human_comment_author=$(echo "$last_human_comment_json" | jq -r '.user.login // "无"')
+            last_human_comment_body=$(echo "$last_human_comment_json" | jq -r '.body // ""')
+            last_human_comment_url=$(echo "$last_human_comment_json" | jq -r '.html_url // ""')
+
+            last_human_comment_body=$(printf '%s' "$last_human_comment_body" \
+              | tr '\r\n' ' ' \
+              | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
+
+            if [ -z "$last_human_comment_body" ]; then
+              last_human_comment_body='（仅包含空白字符）'
+            fi
+          fi
+
           existing_id=$(echo "$comments_json" | jq -r --arg marker "$marker" '.[] | select((.body // "") | contains($marker)) | .id' | head -n 1)
 
           pr_title="${PR_TITLE:-unknown}"
@@ -145,6 +176,32 @@ jobs:
               mention_text="@$pr_author"
             else
               mention_text="$mention_text；@$pr_author"
+            fi
+          fi
+
+          if [ "${PR_MERGED}" != "true" ]; then
+            closer_has_required_comment="false"
+            if [ "$last_human_comment_author" = "$pr_closed_by" ] && \
+               [ "$last_human_comment_body" != "无" ] && \
+               [ "$last_human_comment_body" != "（仅包含空白字符）" ]; then
+              closer_has_required_comment="true"
+            fi
+
+            if [ "$closer_has_required_comment" != "true" ]; then
+              run_gh_api "恢复未合规关闭的PR" "api-first" --method PATCH \
+                -H "Accept: application/vnd.github+json" \
+                "repos/$REPO/pulls/$issue_number" \
+                -f state='open' >/dev/null
+
+              enforcement_body='当前PR未说明关闭原因，无法关闭，请在评论区补充关闭原因'
+
+              run_gh_api "发布关闭校验失败提示" "comment-only" --method POST \
+                -H "Accept: application/vnd.github+json" \
+                "repos/$REPO/issues/$issue_number/comments" \
+                -f body="$enforcement_body" >/dev/null
+
+              echo "❌ 未合并关闭校验失败：关闭人未提供符合要求的评论，PR 已恢复为打开状态。"
+              exit 1
             fi
           fi
 
@@ -170,7 +227,7 @@ jobs:
               echo "- 合并人: $merged_by"
               echo "- 合并提交: $merge_commit_sha"
             else
-              echo "- 关闭原因: 未合并直接关闭"
+              echo "- 关闭原因: $last_human_comment_body"
               echo "- 关闭人: $pr_closed_by"
             fi
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -9,7 +9,7 @@ on:
       - Version.props
       - chore/Fonts.zip
       - src/**
-      - .github/workflows/release.yml
+      - .github/workflows/release-build.yml
   # 保留手动触发入口，便于维护者在 GitHub Actions 页面重新执行发布流程。
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           }
 
           Get-ChildItem -LiteralPath $env:GITHUB_WORKSPACE -Force | Remove-Item -Recurse -Force
-          Copy-Item -LiteralPath (Join-Path $sourceRoot.FullName '*') -Destination $env:GITHUB_WORKSPACE -Recurse -Force
+          Copy-Item -Path (Join-Path $sourceRoot.FullName '*') -Destination $env:GITHUB_WORKSPACE -Recurse -Force
           "已通过 GitHub REST API 下载当前提交源码：${{ github.sha }}。" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
 
       - name: 🧰 安装 .NET SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,246 @@
+name: 📦 自动构建发布版本
+
+on:
+  # 只有主分支中会影响发布内容的文件变化时才自动发版。
+  push:
+    branches:
+      - main
+    paths:
+      - Version.props
+      - chore/Fonts.zip
+      - src/**
+      - .github/workflows/release.yml
+  # 保留手动触发入口，便于维护者在 GitHub Actions 页面重新执行发布流程。
+  workflow_dispatch:
+
+concurrency:
+  # 同一分支的发布流程串行执行，避免两个 Release 同时争用同一个版本号。
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  # 创建 tag、创建 Release、上传 Release 资产均需要 contents: write。
+  contents: write
+
+jobs:
+  release:
+    name: 📦 构建并创建 GitHub Release
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: 📦 执行代码检出
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # 不使用 checkout Action，直接通过 GitHub REST API 下载当前提交源码归档。
+          $archivePath = Join-Path $env:RUNNER_TEMP 'source.zip'
+          $extractPath = Join-Path $env:RUNNER_TEMP 'source'
+          $headers = @{
+              Accept = 'application/vnd.github+json'
+              Authorization = "Bearer $env:GH_TOKEN"
+              'X-GitHub-Api-Version' = '2022-11-28'
+          }
+
+          Invoke-WebRequest `
+              -Uri "https://api.github.com/repos/$env:GITHUB_REPOSITORY/zipball/${{ github.sha }}" `
+              -Headers $headers `
+              -OutFile $archivePath
+
+          if (Test-Path -LiteralPath $extractPath) { Remove-Item -LiteralPath $extractPath -Recurse -Force }
+          Expand-Archive -LiteralPath $archivePath -DestinationPath $extractPath -Force
+          $sourceRoot = Get-ChildItem -LiteralPath $extractPath -Directory | Select-Object -First 1
+          if ($null -eq $sourceRoot) {
+              throw 'GitHub API 源码归档解压后未找到源码根目录。'
+          }
+
+          Get-ChildItem -LiteralPath $env:GITHUB_WORKSPACE -Force | Remove-Item -Recurse -Force
+          Copy-Item -LiteralPath (Join-Path $sourceRoot.FullName '*') -Destination $env:GITHUB_WORKSPACE -Recurse -Force
+          "已通过 GitHub REST API 下载当前提交源码：${{ github.sha }}。" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+
+      - name: 🧰 安装 .NET SDK
+        shell: pwsh
+        run: |
+          # 读取 global.json，并通过 Microsoft 官方发布元数据确认 SDK 版本存在。
+          $globalJsonPath = Join-Path $env:GITHUB_WORKSPACE 'global.json'
+          $globalJson = Get-Content -LiteralPath $globalJsonPath -Raw | ConvertFrom-Json
+          $sdkVersion = [string]$globalJson.sdk.version
+          if ([string]::IsNullOrWhiteSpace($sdkVersion)) {
+              throw 'global.json 中缺少 sdk.version。'
+          }
+
+          if ($sdkVersion -notmatch '^(?<channel>\d+\.\d+)\.') {
+              throw "无法从 sdk.version 推断 .NET 发布通道：$sdkVersion"
+          }
+
+          $channelVersion = $Matches.channel
+          $releaseIndex = Invoke-RestMethod 'https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json'
+          $channel = $releaseIndex.'releases-index' | Where-Object { $_.'channel-version' -eq $channelVersion } | Select-Object -First 1
+          if ($null -eq $channel) {
+              throw "Microsoft .NET 发布元数据中未找到 $channelVersion 通道。"
+          }
+
+          $releaseMetadata = Invoke-RestMethod $channel.'releases.json'
+          $sdkExists = $releaseMetadata.releases.sdks.version -contains $sdkVersion
+          if (-not $sdkExists) {
+              throw "Microsoft .NET 发布元数据中未找到 SDK $sdkVersion。"
+          }
+
+          $installDir = Join-Path $env:RUNNER_TEMP 'dotnet-sdk'
+          New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+          $installScript = Join-Path $env:RUNNER_TEMP 'dotnet-install.ps1'
+          # 使用官方 dotnet-install.ps1 安装指定 SDK，避免固定 setup-dotnet Action 版本。
+          Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile $installScript
+
+          & $installScript -Version $sdkVersion -InstallDir $installDir -NoPath
+          if ($LASTEXITCODE -ne 0) {
+              throw ".NET SDK $sdkVersion 安装失败。"
+          }
+
+          $installDir | Add-Content -LiteralPath $env:GITHUB_PATH
+          "DOTNET_ROOT=$installDir" | Add-Content -LiteralPath $env:GITHUB_ENV
+          "已通过 Microsoft .NET 发布元数据安装 SDK $sdkVersion。" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+
+      - name: 🔎 读取并对比版本
+        id: version
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Version.props 是发布版本的唯一来源：Tag 使用 vX.Y，标题保留构建号。
+          $versionFile = Join-Path $env:GITHUB_WORKSPACE 'Version.props'
+          [xml]$versionXml = Get-Content -LiteralPath $versionFile -Raw
+
+          $displayVersion = [string]$versionXml.Project.PropertyGroup.PluginDisplayVersion
+          $buildId = [string]$versionXml.Project.PropertyGroup.PluginBuildId
+          if ([string]::IsNullOrWhiteSpace($displayVersion) -or [string]::IsNullOrWhiteSpace($buildId)) {
+              throw 'Version.props 中缺少 PluginDisplayVersion 或 PluginBuildId。'
+          }
+          if ($displayVersion -notmatch '^\d+\.\d+$') {
+              throw "PluginDisplayVersion 必须保持 X.Y 格式，当前值：$displayVersion"
+          }
+
+          $tagName = "v$displayVersion"
+          $releaseTitle = "AFR v$displayVersion ($buildId)"
+          # latestTag 用于生成变更记录；existingRelease 用于避免重复发布同一版本。
+          $latestTag = gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // ""'
+          $existingRelease = gh release view $tagName --json tagName --jq '.tagName' 2>$null
+
+          "display_version=$displayVersion" >> $env:GITHUB_OUTPUT
+          "build_id=$buildId" >> $env:GITHUB_OUTPUT
+          "tag_name=$tagName" >> $env:GITHUB_OUTPUT
+          "release_title=$releaseTitle" >> $env:GITHUB_OUTPUT
+          "latest_tag=$latestTag" >> $env:GITHUB_OUTPUT
+
+          if (-not [string]::IsNullOrWhiteSpace($existingRelease)) {
+              "should_release=false" >> $env:GITHUB_OUTPUT
+              "版本 $tagName 已存在 Release，跳过构建与发布。" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+              exit 0
+          }
+
+          "should_release=true" >> $env:GITHUB_OUTPUT
+          if ([string]::IsNullOrWhiteSpace($latestTag)) {
+              "当前版本：$tagName；仓库暂无历史 Release，将创建首个 Release。" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+          } else {
+              "当前版本：$tagName；最新 Release：$latestTag；检测到版本不同，将构建并创建 Release。" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+          }
+
+      - name: 🏗️ 构建部署器
+        if: steps.version.outputs.should_release == 'true'
+        shell: pwsh
+        run: ./src/AFR.Deployer/Publish-Deployer.ps1
+
+      - name: 📦 打包发布资产
+        if: steps.version.outputs.should_release == 'true'
+        id: package
+        shell: pwsh
+        run: |
+          # GitHub Release 会自动提供源码 zip/tar；这里仅额外上传部署器 EXE 与字体压缩包。
+          $tagName = '${{ steps.version.outputs.tag_name }}'
+          $safeTag = $tagName -replace '[^0-9A-Za-z._-]', '-'
+          $publishDir = Join-Path $env:GITHUB_WORKSPACE 'publish/AFR.Deployer'
+          $fontsSourcePath = Join-Path $env:GITHUB_WORKSPACE 'chore/Fonts.zip'
+          $assetDir = Join-Path $env:GITHUB_WORKSPACE 'artifacts/ReleaseAssets'
+          New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
+
+          $exeSourcePath = Join-Path $publishDir 'AFR-Deployer.exe'
+          $exeAssetPath = Join-Path $assetDir 'AFR-Deployer.exe'
+          $fontsAssetPath = Join-Path $assetDir 'Fonts.zip'
+          if (Test-Path -LiteralPath $exeAssetPath) { Remove-Item -LiteralPath $exeAssetPath -Force }
+          if (Test-Path -LiteralPath $fontsAssetPath) { Remove-Item -LiteralPath $fontsAssetPath -Force }
+          if (-not (Test-Path -LiteralPath $exeSourcePath)) {
+              throw '未找到 publish/AFR.Deployer/AFR-Deployer.exe，无法发布部署工具程序。'
+          }
+          if (-not (Test-Path -LiteralPath $fontsSourcePath)) {
+              throw '未找到 chore/Fonts.zip，无法发布字体压缩包。'
+          }
+
+          Copy-Item -LiteralPath $exeSourcePath -Destination $exeAssetPath -Force
+          Copy-Item -LiteralPath $fontsSourcePath -Destination $fontsAssetPath -Force
+
+          "exe_path=$exeAssetPath" >> $env:GITHUB_OUTPUT
+          "fonts_path=$fontsAssetPath" >> $env:GITHUB_OUTPUT
+
+      - name: 📝 生成发布说明
+        if: steps.version.outputs.should_release == 'true'
+        id: notes
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # 发布说明保持简洁：下载说明 + 相对上一 Release 的提交列表。
+          $notesPath = Join-Path $env:GITHUB_WORKSPACE 'release-notes.md'
+          $tagName = '${{ steps.version.outputs.tag_name }}'
+          $latestTag = '${{ steps.version.outputs.latest_tag }}'
+          $repoUrl = "https://github.com/$env:GITHUB_REPOSITORY"
+
+          $lines = [System.Collections.Generic.List[string]]::new()
+          $lines.Add('## 🚀 下载说明')
+          $lines.Add('')
+          $lines.Add('| 文件 | 用途 |')
+          $lines.Add('| --- | --- |')
+          $lines.Add('| `AFR-Deployer.exe` | 部署工具，双击运行后选择需要安装的 AutoCAD 版本。 |')
+          $lines.Add('| `Fonts.zip` | 字体压缩包，用于手动补充或备份字体资源。 |')
+          $lines.Add('')
+          $lines.Add('## 📝 变更记录')
+          $lines.Add('')
+
+          if (-not [string]::IsNullOrWhiteSpace($latestTag)) {
+              # 无 git 历史时使用 GitHub Compare API 生成变更记录。
+              $comparison = gh api "repos/$env:GITHUB_REPOSITORY/compare/$latestTag...${{ github.sha }}" | ConvertFrom-Json
+              if ($comparison.commits.Count -gt 0) {
+                  foreach ($commit in $comparison.commits) {
+                      $subject = ([string]$commit.commit.message -split "`n")[0]
+                      $shortSha = ([string]$commit.sha).Substring(0, 7)
+                      $author = [string]$commit.author.login
+                      if ([string]::IsNullOrWhiteSpace($author)) {
+                          $lines.Add("- $subject ([$shortSha]($repoUrl/commit/$($commit.sha)))")
+                      } else {
+                          $lines.Add("- $subject by @$author ([$shortSha]($repoUrl/commit/$($commit.sha)))")
+                      }
+                  }
+              } else {
+                  $lines.Add('- 本次发布未检测到相对上一版本的新提交。')
+              }
+          }
+
+          $lines | Set-Content -LiteralPath $notesPath -Encoding utf8
+          "notes_path=$notesPath" >> $env:GITHUB_OUTPUT
+
+      - name: 🚀 创建 GitHub Release
+        if: steps.version.outputs.should_release == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # gh release create 会在 tag 不存在时基于 --target 自动创建 tag。
+          gh release create '${{ steps.version.outputs.tag_name }}' `
+            '${{ steps.package.outputs.exe_path }}' `
+            '${{ steps.package.outputs.fonts_path }}' `
+            --target '${{ github.sha }}' `
+            --title '${{ steps.version.outputs.release_title }}' `
+            --notes-file '${{ steps.notes.outputs.notes_path }}' `
+            --latest
+
+          "已创建 Release：${{ steps.version.outputs.tag_name }}" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-test-branch.yml
+++ b/.github/workflows/sync-test-branch.yml
@@ -10,13 +10,7 @@
 name: 🔄 重置测试分支到主分支
 
 on:
-  push:
-    branches:
-      - main
-  pull_request_target:
-    branches:
-      - main
-    types: [closed]
+  workflow_call:
 
 concurrency:
   group: sync-test-branch

--- a/.github/workflows/sync-test-branch.yml
+++ b/.github/workflows/sync-test-branch.yml
@@ -33,7 +33,7 @@ jobs:
         github.event_name == 'pull_request_target' &&
         github.event.pull_request.merged == true &&
         github.event.pull_request.head.ref != 'test' &&
-        contains(fromJSON(vars.TRUSTED_DEVELOPERS), github.event.pull_request.user.login)
+        contains(fromJSON(vars.TRUSTED_DEVELOPERS || '[]'), github.event.pull_request.user.login)
       )
 
     permissions:

--- a/docs/developer-guide-advanced.md
+++ b/docs/developer-guide-advanced.md
@@ -100,7 +100,38 @@ AFR.Core -> AFR.UI -> AFR.AutoCAD -> AFR-ACAD20XX
 - `MTextInlineFontReplacer`：看替换前后 `mtext.Contents`；
 - `ExecutionController.Execute` 第三阶段：核对三组修复记录合并结果。
 
-## 8. 回归清单（进阶）
+## 8. 部署器发布脚本
+
+部署器 EXE 由 `src/AFR.Deployer/Publish-Deployer.ps1` 统一生成，不手工复制 DLL 或直接发布 `AFR.Deployer.csproj`。
+
+脚本职责：
+
+1. 自动发现 `src/AutoCAD/AFR-ACAD*/AFR-ACAD*.csproj`；
+2. Release 构建每个版本壳；
+3. 依赖 `Directory.Build.props` 的 `CopyDllToReleases` 目标，将 DLL 汇聚到 `artifacts/Releases/`；
+4. 复制 `AFR-ACAD*.dll` 与 `AFR-ACAD*.cad.json` 到 `src/AFR.Deployer/Resources/`；
+5. 发布 `AFR.Deployer` 自包含单文件 EXE。
+
+常用命令：
+
+```powershell
+./src/AFR.Deployer/Publish-Deployer.ps1
+./src/AFR.Deployer/Publish-Deployer.ps1 -SkipPluginBuild
+```
+
+输出约定：
+
+```text
+publish/AFR.Deployer/AFR-Deployer.exe
+```
+
+注意事项：
+
+- EXE 文件名由 `AFR.Deployer.csproj` 的 `<AssemblyName>AFR-Deployer</AssemblyName>` 决定，不在发布后重命名。
+- 新增 CAD 版本时必须确保版本壳 `.csproj` 写入 `CadBrand` / `CadVersion` / `CadRegistryBasePath`，否则 `.cad.json` 元数据不会正确生成。
+- `Version.props` 是部署器与插件 DLL 的统一版本来源，发版只修改该文件。
+
+## 9. 回归清单（进阶）
 
 - [ ] 不同触发源（Startup / Command / DocumentCreated）都验证
 - [ ] Hook on/off 两条路径验证
@@ -108,7 +139,7 @@ AFR.Core -> AFR.UI -> AFR.AutoCAD -> AFR-ACAD20XX
 - [ ] MText `\F` / `\f` / 参数段 / 路径残留 / `@` 前缀都覆盖
 - [ ] Release 构建下 Debug 功能完全排除
 
-## 9. 代码评审关注点（建议）
+## 10. 代码评审关注点（建议）
 
 - 是否破坏层级依赖方向；
 - 是否引入无必要抽象；

--- a/docs/developer-guide-beginner.md
+++ b/docs/developer-guide-beginner.md
@@ -64,9 +64,35 @@ dotnet build src/AutoCAD/AFR-ACAD20XX/AFR-ACAD20XX.csproj
 4. 执行 `AFRLOG` 查看当前图纸的检测与替换结果。
 5. 如需调试 MText 场景，再在 Debug 构建下执行 `AFRINSERT` / `AFRVIEW` 建立“输入-输出”直觉。
 
-## 7. 新增命令的正确姿势（最容易漏）
+## 7. 生成部署器 EXE
 
-### 6.1 写命令类
+正式分发默认使用部署器安装，不手动 `NETLOAD`。生成部署器 EXE 时，在仓库根目录运行：
+
+```powershell
+./src/AFR.Deployer/Publish-Deployer.ps1
+```
+
+脚本会自动：
+
+1. Release 构建所有 `src/AutoCAD/AFR-ACAD20XX/` 插件 DLL；
+2. 将插件 DLL 与 `.cad.json` 元数据复制到 `src/AFR.Deployer/Resources/`；
+3. 发布自包含单文件部署器。
+
+最终输出：
+
+```text
+publish/AFR.Deployer/AFR-Deployer.exe
+```
+
+如果只是调试部署器界面或资源嵌入，且插件 DLL 已经构建过，可跳过插件重建：
+
+```powershell
+./src/AFR.Deployer/Publish-Deployer.ps1 -SkipPluginBuild
+```
+
+## 8. 新增命令的正确姿势（最容易漏）
+
+### 8.1 写命令类
 
 放到：`src/AutoCAD/AFR.AutoCAD/Commands/`
 
@@ -77,7 +103,7 @@ dotnet build src/AutoCAD/AFR-ACAD20XX/AFR-ACAD20XX.csproj
 public void YourCommand() { }
 ```
 
-### 6.2 注册命令类（必须）
+### 8.2 注册命令类（必须）
 
 修改：`src/AutoCAD/AFR-ACAD20XX/PluginEntry.cs`
 
@@ -95,7 +121,7 @@ public void YourCommand() { }
 #endif
 ```
 
-## 8. 新手常见错误
+## 9. 新手常见错误
 
 ### 错误 1：命令写了但 CAD 说无此命令
 
@@ -121,15 +147,16 @@ public void YourCommand() { }
 2. 确认当前是 Debug 配置；
 3. 重新构建并重启调试。
 
-## 9. 日常开发建议（新手版）
+## 10. 日常开发建议（新手版）
 
 - 先定位，再改代码：优先看 `ExecutionController` 调用链。
 - 先加日志，再动逻辑：避免“改完不知道哪里坏”。
 - 每次只改一个小目标：例如“只改 MText 解析，不碰 Hook”。
 
-## 10. 提交前快速检查
+## 11. 提交前快速检查
 
 - [ ] `dotnet build` 通过
+- [ ] 发布前已运行 `Publish-Deployer.ps1` 生成 `AFR-Deployer.exe`
 - [ ] 新命令已注册到 `PluginEntry.cs`
 - [ ] 没有把 AutoCAD 类型放进 `AFR.Core` / `AFR.UI`
 - [ ] Debug 功能已用 `#if DEBUG` 控制

--- a/src/AFR.Deployer/AFR.Deployer.csproj
+++ b/src/AFR.Deployer/AFR.Deployer.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
     <RootNamespace>AFR.Deployer</RootNamespace>
-    <AssemblyName>AFR.Deployer</AssemblyName>
+    <AssemblyName>AFR-Deployer</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/src/AFR.Deployer/Publish-Deployer.ps1
+++ b/src/AFR.Deployer/Publish-Deployer.ps1
@@ -153,11 +153,7 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-$defaultExePath = Join-Path $PublishOutput "AFR.Deployer.exe"
-$exePath        = Join-Path $PublishOutput "AFR-Deployer.exe"
-if (Test-Path $defaultExePath) {
-    Move-Item -Path $defaultExePath -Destination $exePath -Force
-}
+$exePath = Join-Path $PublishOutput "AFR-Deployer.exe"
 $sizeMB  = [math]::Round((Get-Item $exePath).Length / 1MB, 1)
 Write-Host "`n✓ 发布完成！" -ForegroundColor Green
 Write-Host "  输出：$exePath ($sizeMB MB)" -ForegroundColor Green

--- a/src/AFR.Deployer/Publish-Deployer.ps1
+++ b/src/AFR.Deployer/Publish-Deployer.ps1
@@ -153,7 +153,11 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-$exePath = Join-Path $PublishOutput "AFR.Deployer.exe"
+$defaultExePath = Join-Path $PublishOutput "AFR.Deployer.exe"
+$exePath        = Join-Path $PublishOutput "AFR-Deployer.exe"
+if (Test-Path $defaultExePath) {
+    Move-Item -Path $defaultExePath -Destination $exePath -Force
+}
 $sizeMB  = [math]::Round((Get-Item $exePath).Length / 1MB, 1)
 Write-Host "`n✓ 发布完成！" -ForegroundColor Green
 Write-Host "  输出：$exePath ($sizeMB MB)" -ForegroundColor Green


### PR DESCRIPTION
**变更类型：** 混合变更（ci/feat）

**变更摘要：**
重构 GitHub Actions 工作流，引入编排工作流解耦触发逻辑；新增发布构建链路与 PR 关闭校验，提升 CI/CD 可维护性与发布安全性。

**主要改动：**
- **新功能：** 新增 orchestrate-pr-events、orchestrate-pr-close 与 orchestrate-push-events 编排工作流，统一管理 PR 事件与推送事件触发，消除子工作流中的重复 on 配置。
- **新功能：** 新增 release-build.yml 自动构建发布链路，基于 Version.props 生成 Git tag，打包部署器 EXE 与字体包，确保版本发布一致性。
- **缺陷修复：** 在 pr-close-notify.yml 中增加未合并关闭校验：要求关闭人提交符合格式的评论，否则自动恢复 PR 打开状态并提示，防止非规范关闭。
- **重构：** 将 branch-policy-check、merge-permission、pr-auto-approve、pr-auto-main、pr-auto-test、pr-close-notify 等独立工作流触发器统一切换为 workflow_call，降低事件耦合与回归风险。
- **配置更新：** 在 pr-auto-approve.yml 中处理 TRUSTED_DEVELOPERS 变量未定义时的空值边界条件，提升配置项的健壮性。