### PR TITLE
chore: 更新 .gitignore 并移除 inspect-types.ps1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,7 @@ MigrationBackup/
 FodyWeavers.xsd
 /src/AFR.Deployer/Resources
 /_readme_patch.ps1
+/chore/inspect-resources.ps1
+/chore/inspect-types.ps1
+/tools/diff-procmon.ps1
+/chore/inspect-types.ps1

--- a/chore/inspect-types.ps1
+++ b/chore/inspect-types.ps1
@@ -1,8 +1,0 @@
-param([string]$Path)
-$bytes = [System.IO.File]::ReadAllBytes($Path)
-$asm = [System.Reflection.Assembly]::Load($bytes)
-$t = $asm.GetTypes() | Where-Object { $_.Name -eq 'AppInitializer' }
-if (-not $t) { Write-Host 'AppInitializer not found'; exit 1 }
-Write-Host "Type: $($t.FullName)"
-$bf = [System.Reflection.BindingFlags] 'NonPublic, Public, Static, Instance, DeclaredOnly'
-$t.GetMethods($bf) | Sort-Object Name | ForEach-Object { Write-Host "  $($_.Name)" }


### PR DESCRIPTION
**变更类型：** chore

**变更摘要：**
更新 .gitignore 文件以忽略 chroe 和 tools 目录下的杂项脚本，同时删除不再使用的 inspect-types.ps1 脚本，以保持仓库清洁并减少无关文件的版本控制干扰。

**主要改动：**
- 杂项维护：在 .gitignore 中新增 /chore/inspect-resources.ps1、/chore/inspect-types.ps1、/tools/diff-procmon.ps1 的忽略条目，避免这些杂项脚本被意外纳入版本跟踪。
- 清理：移除 chroe/inspect-types.ps1 文件，该脚本用于程序集类型检查，已无使用必要，删除可减少仓库冗余文件。