### PR TITLE
docs(core): 精简 RegistryService XML 注释并更新编码规范

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,7 +85,7 @@ AFR-ACAD20XX（版本适配壳，仅 PluginEntry + ICadPlatform 实现）
 - 服务类使用 `internal sealed class`（非接口实现用 `static class`）
 - 接口放在 `AFR.Core/Abstractions/`，命名以 `I` 开头
 - 单例模式使用 `Lazy<T>` 惰性初始化（参考 `ExecutionController`、`LogService`）
-- XML 文档注释覆盖所有 `public` / `internal` 类型及其公共成员，使用 `<summary>` + `<para>` 格式
+- XML 文档注释覆盖所有 `public` / `internal` 类型及其公共成员，使用 `<summary>` + `<para>` 格式；减少仅重复参数名含义的 XML `<param>` 注释，避免冗余注释。
 - 条件编译：`DiagnosticLogger` 仅在 `#if DEBUG` 下编译，Release 自动移除
 
 ### WPF / MVVM

--- a/src/AFR.Core/Services/RegistryService.cs
+++ b/src/AFR.Core/Services/RegistryService.cs
@@ -3,18 +3,15 @@ using Microsoft.Win32;
 namespace AFR.Services;
 
 /// <summary>
-/// 底层 Windows 注册表读写工具类，不包含任何业务逻辑。
+/// 底层 Windows 注册表读写工具类，不承载业务逻辑。
 /// <para>
 /// 提供类型安全的 string / DWORD 读写，以及子键枚举、存在性检查、删除等操作。
-/// 所有方法在遇到注册表异常时均静默处理，返回 null / false / 空数组等安全默认值。
+/// 读取与查询方法在遇到注册表异常时会静默处理，并返回安全默认值。
 /// </para>
 /// </summary>
 public static class RegistryService
 {
-    /// <summary>从注册表读取一个字符串值。找不到或出错时返回 null。</summary>
-    /// <param name="baseKey">注册表根键（如 Registry.CurrentUser）。</param>
-    /// <param name="subKeyPath">子键路径。</param>
-    /// <param name="valueName">值名称。</param>
+    /// <summary>从注册表读取字符串值。找不到或读取失败时返回 null。</summary>
     public static string? ReadString(RegistryKey baseKey, string subKeyPath, string valueName)
     {
         try
@@ -28,10 +25,7 @@ public static class RegistryService
         }
     }
 
-    /// <summary>从注册表读取一个 DWORD（int）值。找不到或类型不匹配时返回 null。</summary>
-    /// <param name="baseKey">注册表根键。</param>
-    /// <param name="subKeyPath">子键路径。</param>
-    /// <param name="valueName">值名称。</param>
+    /// <summary>从注册表读取 DWORD（int）值。找不到、类型不匹配或读取失败时返回 null。</summary>
     public static int? ReadDword(RegistryKey baseKey, string subKeyPath, string valueName)
     {
         try
@@ -46,31 +40,21 @@ public static class RegistryService
         }
     }
 
-    /// <summary>向注册表写入一个字符串值。若子键不存在会自动创建。</summary>
-    /// <param name="baseKey">注册表根键。</param>
-    /// <param name="subKeyPath">子键路径。</param>
-    /// <param name="valueName">值名称。</param>
-    /// <param name="value">要写入的字符串值。</param>
+    /// <summary>向注册表写入字符串值。若子键不存在则自动创建。</summary>
     public static void WriteString(RegistryKey baseKey, string subKeyPath, string valueName, string value)
     {
         using var key = baseKey.CreateSubKey(subKeyPath, true);
         key.SetValue(valueName, value, RegistryValueKind.String);
     }
 
-    /// <summary>向注册表写入一个 DWORD（int）值。若子键不存在会自动创建。</summary>
-    /// <param name="baseKey">注册表根键。</param>
-    /// <param name="subKeyPath">子键路径。</param>
-    /// <param name="valueName">值名称。</param>
-    /// <param name="value">要写入的整数值。</param>
+    /// <summary>向注册表写入 DWORD（int）值。若子键不存在则自动创建。</summary>
     public static void WriteDword(RegistryKey baseKey, string subKeyPath, string valueName, int value)
     {
         using var key = baseKey.CreateSubKey(subKeyPath, true);
         key.SetValue(valueName, value, RegistryValueKind.DWord);
     }
 
-    /// <summary>检查指定的注册表子键是否存在。</summary>
-    /// <param name="baseKey">注册表根键。</param>
-    /// <param name="subKeyPath">要检查的子键路径。</param>
+    /// <summary>检查指定注册表子键是否存在。</summary>
     public static bool KeyExists(RegistryKey baseKey, string subKeyPath)
     {
         try
@@ -84,10 +68,7 @@ public static class RegistryService
         }
     }
 
-    /// <summary>检查指定子键下的某个值是否存在。</summary>
-    /// <param name="baseKey">注册表根键。</param>
-    /// <param name="subKeyPath">子键路径。</param>
-    /// <param name="valueName">要检查的值名称。</param>
+    /// <summary>检查指定子键下的值是否存在。</summary>
     public static bool ValueExists(RegistryKey baseKey, string subKeyPath, string valueName)
     {
         try
@@ -101,9 +82,7 @@ public static class RegistryService
         }
     }
 
-    /// <summary>获取指定子键下的所有直接子键名称。找不到或出错时返回空数组。</summary>
-    /// <param name="baseKey">注册表根键。</param>
-    /// <param name="subKeyPath">子键路径。</param>
+    /// <summary>获取指定子键下的所有直接子键名称。找不到或读取失败时返回空数组。</summary>
     public static string[] GetSubKeyNames(RegistryKey baseKey, string subKeyPath)
     {
         try
@@ -119,11 +98,9 @@ public static class RegistryService
 
     /// <summary>
     /// 递归删除指定路径的注册表子键及其所有子项和值。
-    /// 若子键不存在也不会抛出异常。
+    /// 若子键不存在或删除失败，则返回 false。
     /// </summary>
-    /// <param name="baseKey">注册表根键。</param>
-    /// <param name="subKeyPath">要删除的子键路径。</param>
-    /// <returns>删除成功返回 true，出错返回 false。</returns>
+    /// <returns>删除成功返回 true，否则返回 false。</returns>
     public static bool DeleteSubKeyTree(RegistryKey baseKey, string subKeyPath)
     {
         try


### PR DESCRIPTION
**变更类型：** 文档更新

**变更摘要：**
精简 RegistryService 类的 XML 文档注释，移除冗余的参数描述注释并统一异常行为说明，同时更新 .github/copilot-instructions.md 中的注释规范，以降低文档维护成本并提升可读性。

**主要改动：**
- 文档更新：在 RegistryService 类中移除所有重复参数含义的 `<param>` 注释，减少注释冗余并降低后续维护的回归风险。
- 文档更新：统一 RegistryService 各方法的 `<summary>` 描述，明确异常场景下的安全默认值返回行为，提升文档的一致性和可观测性。
- 文档更新：在 .github/copilot-instructions.md 中补充“减少仅重复参数名含义的 XML 注释”的约束，对齐编码规范以减少冗余注释的产生。