### PR TITLE
fix(ci): 修正发布构建流程中版本格式为X.Y.Z

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -143,7 +143,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          # Version.props 是发布版本的唯一来源：Tag 使用 vX.Y，标题保留构建号。
+          # Version.props 是发布版本的唯一来源：Tag 使用 vX.Y.Z，标题保留构建号。
           $versionFile = Join-Path $env:GITHUB_WORKSPACE 'Version.props'
           [xml]$versionXml = Get-Content -LiteralPath $versionFile -Raw
 
@@ -152,8 +152,8 @@ jobs:
           if ([string]::IsNullOrWhiteSpace($displayVersion) -or [string]::IsNullOrWhiteSpace($buildId)) {
               throw 'Version.props 中缺少 PluginDisplayVersion 或 PluginBuildId。'
           }
-          if ($displayVersion -notmatch '^\d+\.\d+$') {
-              throw "PluginDisplayVersion 必须保持 X.Y 格式，当前值：$displayVersion"
+          if ($displayVersion -notmatch '^\d+\.\d+\.\d+$') {
+              throw "PluginDisplayVersion 必须保持 X.Y.Z 格式，当前值：$displayVersion"
           }
 
           $tagName = "v$displayVersion"
@@ -245,9 +245,7 @@ jobs:
         run: |
           # 发布说明优先使用 AI 基于“相对上一 Release 的相关代码差异”生成，并过滤工作流/文档等无关项。
           $notesPath = Join-Path $env:GITHUB_WORKSPACE 'release-notes.md'
-          $versionFile = Join-Path $env:GITHUB_WORKSPACE 'Version.props'
-          [xml]$versionXml = Get-Content -LiteralPath $versionFile -Raw
-          $tagName = "v$([string]$versionXml.Project.PropertyGroup.PluginDisplayVersion)"
+          $tagName = '${{ steps.version.outputs.tag_name }}'
           $latestTag = gh release list --repo $env:GITHUB_REPOSITORY --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // ""'
           $maxDiffChars = 16000
           $fallbackReason = ''

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -867,7 +867,7 @@ jobs:
               }
 
               $versionResponse = Invoke-WebRequest `
-                  -Uri "[https://api.github.com/repos/$env:GH_REPO/contents/Version.props?ref=$env:GITHUB_SHA](https://api.github.com/repos/$env:GH_REPO/contents/Version.props?ref=$env:GITHUB_SHA)" `
+                  -Uri "https://api.github.com/repos/$env:GH_REPO/contents/Version.props?ref=$env:GITHUB_SHA" `
                   -Headers $headers `
                   -SkipHttpErrorCheck
 
@@ -972,7 +972,7 @@ jobs:
               }
 
               $releaseLookup = Invoke-WebRequest `
-                  -Uri "[https://api.github.com/repos/$env:GH_REPO/releases/tags/$tagName](https://api.github.com/repos/$env:GH_REPO/releases/tags/$tagName)" `
+                  -Uri "https://api.github.com/repos/$env:GH_REPO/releases/tags/$tagName" `
                   -Headers $headers `
                   -SkipHttpErrorCheck
 


### PR DESCRIPTION
**变更类型：** 混合变更（fix/refactor）

**变更摘要：**
修正版本验证和标签生成逻辑以支持X.Y.Z三位版本号，并清理构建脚本中的变量引用和URL格式，提升发布流程稳定性和可维护性。

**主要改动：**
- 缺陷修复：将 PluginDisplayVersion 验证正则从 `^\d+\.\d+$` 放宽为 `^\d+\.\d+\.\d+$`，并同步更新注释说明，适配三位版本号场景。
- 其他：改用预计算的 `${{ steps.version.outputs.tag_name }}` 变量替代动态读取 Version.props 文件，减少文件 I/O 和潜在解析风险。
- 其他：修复 GitHub API 请求 URL 中多余的方括号包裹，消除 URI 解析异常隐患。