### PR TITLE
ci: 修复发布构建中版本标签读取方式

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -242,10 +242,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           DEEPSEEK_API_KEY: ${{ secrets.DeepSeek_API_KEY }}
+          TAG_NAME: ${{ steps.version.outputs.tag_name }}
         run: |
           # 发布说明优先使用 AI 基于“相对上一 Release 的相关代码差异”生成，并过滤工作流/文档等无关项。
           $notesPath = Join-Path $env:GITHUB_WORKSPACE 'release-notes.md'
-          $tagName = '${{ steps.version.outputs.tag_name }}'
+          $tagName = [string]$env:TAG_NAME
+          if ([string]::IsNullOrWhiteSpace($tagName)) {
+              throw '生成发布说明时未读取到版本标签。'
+          }
           $latestTag = gh release list --repo $env:GITHUB_REPOSITORY --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // ""'
           $maxDiffChars = 16000
           $fallbackReason = ''


### PR DESCRIPTION
**变更类型：** ci

**变更摘要：**
将直接插值引用版本标签改为通过环境变量传递，并添加空值校验，以提升发布构建流程中版本标签读取的健壮性与可维护性。

**主要改动：**
- 在发布作业中新增 `TAG_NAME` 环境变量，从步骤输出赋值；脚本改为从环境变量 `[string]$env:TAG_NAME` 读取标签值，并增加空值抛出异常，避免因标签缺失导致后续步骤静默失败。